### PR TITLE
Fixes Access to Icon Shown In Share Sheet

### DIFF
--- a/TTOpenInAppActivity/TTOpenInAppActivity.m
+++ b/TTOpenInAppActivity/TTOpenInAppActivity.m
@@ -78,12 +78,14 @@
 
 - (UIImage *)activityImage
 {
-    if([[[UIDevice currentDevice] systemVersion] floatValue] >= 8.0){
-        return [UIImage imageNamed:@"TTOpenInAppActivity8" inBundle:[NSBundle bundleForClass:[self class]] compatibleWithTraitCollection:nil];
-    } else if([[[UIDevice currentDevice] systemVersion] floatValue] >= 7.0){
-        return [UIImage imageNamed:@"TTOpenInAppActivity7" inBundle:[NSBundle bundleForClass:[self class]] compatibleWithTraitCollection:nil];
+    NSBundle *bundle = [NSBundle bundleForClass:[self class]];
+    
+    if ([[[UIDevice currentDevice] systemVersion] floatValue] >= 8.0){
+        return [UIImage imageNamed:@"TTOpenInAppActivity8" inBundle:bundle compatibleWithTraitCollection:nil];
+    } else if ([[[UIDevice currentDevice] systemVersion] floatValue] >= 7.0){
+        return [UIImage imageNamed:@"TTOpenInAppActivity7" inBundle:bundle compatibleWithTraitCollection:nil];
     } else {
-        return [UIImage imageNamed:@"TTOpenInAppActivity" inBundle:[NSBundle bundleForClass:[self class]] compatibleWithTraitCollection:nil];
+        return [UIImage imageNamed:@"TTOpenInAppActivity" inBundle:bundle compatibleWithTraitCollection:nil];
     }
 }
 

--- a/TTOpenInAppActivity/TTOpenInAppActivity.m
+++ b/TTOpenInAppActivity/TTOpenInAppActivity.m
@@ -79,11 +79,11 @@
 - (UIImage *)activityImage
 {
     if([[[UIDevice currentDevice] systemVersion] floatValue] >= 8.0){
-        return [UIImage imageNamed:@"TTOpenInAppActivity8"];
+        return [UIImage imageNamed:@"TTOpenInAppActivity8" inBundle:[NSBundle bundleForClass:[self class]] compatibleWithTraitCollection:nil];
     } else if([[[UIDevice currentDevice] systemVersion] floatValue] >= 7.0){
-        return [UIImage imageNamed:@"TTOpenInAppActivity7"];
+        return [UIImage imageNamed:@"TTOpenInAppActivity7" inBundle:[NSBundle bundleForClass:[self class]] compatibleWithTraitCollection:nil];
     } else {
-        return [UIImage imageNamed:@"TTOpenInAppActivity"];
+        return [UIImage imageNamed:@"TTOpenInAppActivity" inBundle:[NSBundle bundleForClass:[self class]] compatibleWithTraitCollection:nil];
     }
 }
 


### PR DESCRIPTION
In Pinpoint, we’re using `TTOpenInAppActivity` via CocoaPods, but the image is no longer showing in the share sheet. This ensures the proper bundle when accessing the image.

To test in Pinpoint, change the Podfile line that includes `TTOpenInAppActivity` to

```
pod 'TTOpenInAppActivity', :git => 'https://github.com/Lickability/TTOpenInAppActivity.git', :branch => 'fix-missing-image'
```

Then run `bundle exec pod update TTOpenInAppActivity`.

Then run the app, tap a screenshot, tap the share bar button item, and swipe the bottom row over to "Open in …" to view the icon 